### PR TITLE
Change Create SNOW Incident playbook to use `$$data` instead of `$match`

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -117,47 +117,21 @@ To create incidents from events in the `sonargd-instance` collection, follow the
     - Group Label: `No`  
     - Playbook Execution: Check `Synchronous Execution`
     - Enter the following syntax into the text area:  
-
       ```
       {
         "start" : {
-          "run_type" : "row",
-          "row_run" : "<placeholder>",
-          "database_name" : "sonargd",
-          "collection_name" : "instance"
+          "event" : "$$data",
+          "comment" : null,
+          "asset_id" : "service_now"
         }
       }
       ```  
-  1. Navigate to Home->System Management->SonarK Management->Index Patterns.
-  1. Search for `instance`, and select the `sonargd-instance` collection.
-  1. Navigate to Actions->Row, anc click the pen icon to edit the `Create Snow Incident` action button.
-  1. Enter the following json syntax into the args text area, anc click `Save`:  
-      ```
-      {
-          "value": {
-              "start": {
-                  "run_type": "row",
-                  "row_run": [
-                      {
-                          "$match": {
-                              "_id": "$$ejsonData._id"
-                          }
-                      }
-                  ],
-                  "database_name": "sonargd",
-                  "collection_name": "instance"
-              }
-          },
-          "synchronous": true
-      }
-      ```
-
+  1. Navigate to Home->Discover, select the sonargd-instance collection, and click `Create SNOW Incident`.  Enter a comment and click submit.
 
 ## Create incidents from events the `sonargd-session` collection  
 To create incidents from events in the `sonargd-session` collection, follow the following steps:
   1. Navigate to Home->Playbooks->Published Playbooks.
   1. Select the `All Categories` dropdown, and select the `ServiceNow Incident` category filter.
-  1. Navigate to Home->System Management->SonarK Management->Index Patterns.
   1. On the `Create SNOW Incident Record` playbook, click Options->Create SonarK Button, and enter the following:   
     - Select an Index Pattern: `sonargd-session`  
     - Location: `ROW`  
@@ -165,58 +139,15 @@ To create incidents from events in the `sonargd-session` collection, follow the 
     - Group Label: `No`  
     - Playbook Execution: Check `Synchronous Execution`
     - Enter the following syntax into the text area:  
-
       ```
       {
         "start" : {
-          "run_type" : "row",
-          "row_run" : "<placeholder>",
-          "database_name" : "sonargd",
-          "collection_name" : "instance"
+          "event" : "$$data",
+          "comment" : null,
+          "asset_id" : "service_now"
         }
       }
       ```  
-  1. Navigate to Home->System Management->SonarK Management->Index Patterns.
-  1. Search for `session`, and select the `sonargd-session` collection.
-  1. Navigate to Scripted Fields, and click `Add scripted field` and add the following and click Save:
-    - Name: `id_string`  
-    - Language: `sonar`    
-    - Type: `string`  
-    - Format: `string`  
-    - Popularity: LEAVE BLANK  
-    - Script:  
-      ```
-      { "$toString" : "$_id" }
-      ```
-  1. Navigate to Actions->Row, anc click the pen icon to edit the `Create Snow Incident` action button.
-  1. Enter the following json syntax into the args text area, anc click `Save`:  
-      ```
-      {
-          "value": {
-              "start": {
-                  "run_type": "row",
-                  "row_run": [
-                      {
-                          "$match": {
-                              "$expr": {
-                                  "$eq": [
-                                      {
-                                          "$toString": "$_id"
-                                      },
-                                      "$$data.id_string"
-                                  ]
-                              }
-                          }
-                      }
-                  ],
-                  "database_name": "sonargd",
-                  "collection_name": "session"
-              }
-          },
-          "synchronous": true
-      }
-      ```
-  1. Navigate to Home->Discover, select the sonargd-instance collection, and click `Create SNOW Incident`.  Enter a comment and click submit.
   1. Navigate to Home->Discover, select the sonargd-session collection, and click `Create SNOW Incident`.  Enter a comment and click submit.
 
 ## Contributing

--- a/integrations/playbooks/ServiceNow_Incident/create_snow_incident_record.json
+++ b/integrations/playbooks/ServiceNow_Incident/create_snow_incident_record.json
@@ -1,6 +1,6 @@
 [
 {
-  "_id" : "23fc49be-ca46-489e-bb9b-f64382df9b78",
+  "_id" : "ce209970-c125-4b75-8790-94579e305b0f",
   "name" : "Create SNOW Incident Record",
   "description" : "",
   "type" : "playbook",
@@ -10,11 +10,11 @@
     "collection" : "playbook_definitions",
     "page" : "playbooks.xhtml"
   },
-  "version" : 38,
+  "version" : 2,
   "enabled" : true,
   "onlyWarehouse" : false,
   "created" : {
-    "$date" : "2022-09-30T05:04:38.373Z"
+    "$date" : "2022-11-13T03:23:58.252Z"
   },
   "playbook" : {
     "_id" : "18d7a1bb-80d0-490e-bcdc-99c630329a64",
@@ -27,115 +27,52 @@
       "collection" : "playbook_definitions",
       "page" : "playbooks.xhtml"
     },
-    "version" : 38,
+    "version" : 2,
     "enabled" : true,
-    "onlyWarehouse" : false,
-    "created" : {
-      "$date" : "2022-09-29T22:21:40.321Z"
-    },
-    "playbook" : {
-      "_id" : "8114260f-d68d-4ffb-b5a4-b3e8a001015c",
-      "name" : "Create Incident Record",
-      "description" : "",
-      "type" : "playbook",
-      "category" : "ServiceNow Incident",
-      "source" : {
-        "database" : "lmrm__ae",
-        "collection" : "playbook_definitions",
-        "page" : "playbooks.xhtml"
-      },
-      "version" : 38,
-      "enabled" : true,
-      "onlyWarehouse" : false
-    }
+    "onlyWarehouse" : false
   }
 },
 {
-  "_id" : "261d5231-8759-4492-aeea-b4bfa65573f8",
+  "_id" : "7be42e69-5541-4b7b-979c-34c0b2ecac1a",
   "name" : "Create Incident Record",
   "shortname" : "start",
   "type" : "root_node",
-  "playbook" : "23fc49be-ca46-489e-bb9b-f64382df9b78",
+  "playbook" : "ce209970-c125-4b75-8790-94579e305b0f",
   "errorStatus" : "fail",
-  "arguments" : "{ \"run_type\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"string\", \"title\" : \"Run Type\", \"default\" : \"direct\" }, \"required\" : false, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false }, \"row_run\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"object\", \"title\" : \"Row Run\", \"default\" : [{ \"$match\" : { \"_id\" : \"$$ejsonData._id\" } }] }, \"required\" : false, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false }, \"bulk_run\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"array\", \"title\" : \"Bulk Run\", \"default\" : \"$$lmrm.pipeline\" }, \"required\" : false, \"sensitive\" : false, \"contextVariable\" : true, \"alwaysPrompt\" : false }, \"comment\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"string\" }, \"required\" : false, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false }, \"database_name\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"string\", \"default\" : \"sonargd\" }, \"required\" : true, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false }, \"collection_name\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"string\", \"default\" : \"instance\" }, \"required\" : true, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false } }",
-  "children" : ["1eed668e-7cf4-4cd8-ae09-6ed6e294d107"]
+  "arguments" : "{ \"event\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"object\", \"title\" : \"Event\", \"default\" : { } }, \"required\" : true, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false }, \"comment\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"string\", \"title\" : \"Comment\" }, \"required\" : false, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false }, \"asset_id\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"string\", \"title\" : \"Service Now asset_id\", \"description\" : \"To connect to Service Now, the asset_id of the connection that matches type:OPENAPI and auth_mechanism:basic\", \"default\" : \"service_now\" }, \"required\" : true, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false } }",
+  "children" : ["da2fde7a-96d9-44d5-910d-f84a6c4a47b3"]
 },
 {
-  "_id" : "1eed668e-7cf4-4cd8-ae09-6ed6e294d107",
-  "name" : "Was the asset ID provided manually?",
-  "shortname" : "is_direct",
-  "type" : "conditional_node",
-  "playbook" : "23fc49be-ca46-489e-bb9b-f64382df9b78",
-  "arguments" : "{ \"expression\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : true, \"expression\" : \"{ \\\"$cond\\\" : { \\\"if\\\" : { \\\"$eq\\\" : [\\\"$start.arguments.run_type\\\", \\\"direct\\\"] }, \\\"then\\\" : true, \\\"else\\\" : false } }\" } }",
-  "children" : ["55a8e2c9-4e9b-4520-a630-7444bfcee200", "6b9b22e9-517c-405b-81f5-d5ec8ec59fc8"],
-  "end" : ["060b85ad-bfda-436c-a187-2c5cc20d9b1d"]
-},
-{
-  "_id" : "55a8e2c9-4e9b-4520-a630-7444bfcee200",
-  "name" : "Match events based on Kibana's search result",
-  "shortname" : "sonark_aggregate",
-  "type" : "action_node",
-  "playbook" : "23fc49be-ca46-489e-bb9b-f64382df9b78",
-  "errorStatus" : "fail",
-  "arguments" : "{ \"database_name\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"string\", \"description\" : \"The name of the database where the collection is located.\", \"extensions\" : { \"in\" : \"query\" } }, \"required\" : true, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"$start.arguments.database_name\\\"\" }, \"requestBody\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"object\", \"description\" : \"The action's parameters contained in the request data.\", \"extensions\" : { \"in\" : \"body\", \"mediaType\" : \"application/json\" }, \"required\" : [\"aggregation_pipeline\"], \"properties\" : { \"aggregation_pipeline\" : { \"type\" : \"array\", \"description\" : \"A list containing the pipeline stages.\", \"extensions\" : { \"parent\" : \"requestBody\" }, \"items\" : { } } } }, \"required\" : false, \"expanded\" : true, \"sensitive\" : false }, \"remove_limit\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"boolean\", \"title\" : \"Remove Max Documents Limit\", \"description\" : \"If set to \\\"True\\\", removes the document limit that comes by default with SonarK's aggregation pipeline. (Default: True)\", \"default\" : true, \"extensions\" : { \"in\" : \"query\" } }, \"required\" : false, \"sensitive\" : false, \"contextVariable\" : true, \"alwaysPrompt\" : false }, \"collection_name\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"string\", \"description\" : \"The name of the collection where to execute the aggregation.\", \"extensions\" : { \"in\" : \"query\" } }, \"required\" : true, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"$start.arguments.collection_name\\\"\" }, \"aggregation_pipeline\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"array\", \"description\" : \"A list containing the pipeline stages.\", \"extensions\" : { \"parent\" : \"requestBody\" }, \"items\" : { } }, \"required\" : true, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"$pipeline\\\"\", \"enrichment\" : \"[{ \\\"$project\\\" : { \\\"pipeline\\\" : { \\\"$cond\\\" : { \\\"if\\\" : { \\\"$eq\\\" : [\\\"$start.arguments.run_type\\\", \\\"\\\\\\\"row\\\\\\\"\\\"] }, \\\"then\\\" : \\\"$start.arguments.row_run\\\", \\\"else\\\" : \\\"$start.arguments.bulk_run\\\" } } } }]\" } }",
-  "result" : "{ \"schema\" : { \"type\" : \"object\", \"description\" : \"Action completed\", \"properties\" : { \"batch_size\" : { \"type\" : \"string\", \"description\" : \"The number of documents returned.\" }, \"message\" : { \"type\" : \"string\", \"description\" : \"A message informing the execution was successful.\" }, \"results\" : { \"type\" : \"string\", \"description\" : \"A list containing the documents found.\" } } }, \"sensitive\" : false, \"expression\" : \"\" }",
-  "children" : ["10e25ac0-bb2b-404c-b8d3-f446758e8bbe"],
-  "action" : "actions:sonaractions.sonark_actions_sonark_aggregate",
-  "asynchronous" : false
-},
-{
-  "_id" : "10e25ac0-bb2b-404c-b8d3-f446758e8bbe",
-  "name" : "Loop through matched events",
-  "shortname" : "events_loop",
-  "type" : "loop_node",
-  "playbook" : "23fc49be-ca46-489e-bb9b-f64382df9b78",
-  "errorStatus" : "fail",
-  "arguments" : "{ \"items\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : true, \"expression\" : \"\\\"$sonark_aggregate.result.results\\\"\" } }",
-  "children" : ["a36bdcf4-4258-4588-ac50-4ab49938f0e2"],
-  "end" : ["060b85ad-bfda-436c-a187-2c5cc20d9b1d"]
-},
-{
-  "_id" : "a36bdcf4-4258-4588-ac50-4ab49938f0e2",
+  "_id" : "da2fde7a-96d9-44d5-910d-f84a6c4a47b3",
   "name" : "Massage payload for servicenow",
   "shortname" : "payload",
   "type" : "stamp_node",
-  "playbook" : "23fc49be-ca46-489e-bb9b-f64382df9b78",
+  "playbook" : "ce209970-c125-4b75-8790-94579e305b0f",
   "errorStatus" : "fail",
-  "arguments" : "{ \"short_description\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"Server Hostname: $events_loop.item.Server Host Name\\\\r\\\\nDatabase Name: $events_loop.item.Database Name\\\\r\\\\nDB User Name: $events_loop.item.DB User Name\\\"\" }, \"description\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"Server Hostname: $events_loop.item.Server Host Name\\\\nDatabase Name: $events_loop.item.Database Name\\\\nDB User Name: $events_loop.item.DB User Name\\\\nComment: $start.arguments.comment\\\"\" } }",
-  "children" : ["dcdc001f-f871-4a39-b056-c2445d4eed2a"],
+  "arguments" : "{ \"short_description\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"Server Hostname: $start.arguments.event.Server Host Name\\\\nDatabase Name: $start.arguments.event.Database Name\\\\nDB User Name: $start.arguments.event.DB User Name\\\"\" }, \"description\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"Server Hostname: $start.arguments.event.Server Host Name\\\\nDatabase Name: $start.arguments.event.Database Name\\\\nDB User Name: $start.arguments.event.DB User Name\\\\nComment: $start.arguments.comment\\\"\" }, \"event\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"object\" }, \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"$start.arguments.event\\\"\" } }",
+  "result" : "{ \"schema\" : { \"type\" : \"object\" }, \"sensitive\" : false, \"expression\" : \"{ \\\"short_description\\\" : \\\"$payload.arguments.short_description\\\", \\\"description\\\" : \\\"$payload.arguments.description\\\", \\\"assignment_group\\\" : \\\"<work_notes>\\\", \\\"work_notes\\\" : \\\"<work_notes>\\\", \\\"cmdb_ci\\\" : \\\"<cmdb_ci>\\\", \\\"urgency\\\" : \\\"<urgency>\\\", \\\"impact\\\" : \\\"<impact>\\\", \\\"priority\\\" : \\\"<priority>\\\" }\" }",
+  "children" : ["f7a66e87-31cf-42b8-a0a8-ca93b9bbe9cf"],
   "stamp" : "success",
   "message" : ""
 },
 {
-  "_id" : "dcdc001f-f871-4a39-b056-c2445d4eed2a",
-  "name" : "Create Record SonarK",
-  "shortname" : "create_record_sonark",
+  "_id" : "f7a66e87-31cf-42b8-a0a8-ca93b9bbe9cf",
+  "name" : "Create Incident",
+  "shortname" : "create_incident",
   "type" : "action_node",
-  "playbook" : "23fc49be-ca46-489e-bb9b-f64382df9b78",
+  "playbook" : "ce209970-c125-4b75-8790-94579e305b0f",
   "errorStatus" : "fail",
-  "arguments" : "{ \"url\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"{url}/api/now - will be overwritten with asset_id connection 'url' field\", \"default\" : \"https://demo.servicenow.com\", \"extensions\" : { \"in\" : \"server\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"<asset_url>\\\"\" }, \"requestBody\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"object\", \"extensions\" : { \"in\" : \"body\", \"mediaType\" : \"application/json\" } }, \"required\" : false, \"sensitive\" : false, \"runAsProject\" : true, \"expression\" : \"{ \\\"short_description\\\" : \\\"$payload.arguments.short_description\\\", \\\"description\\\" : \\\"$payload.arguments.description\\\", \\\"assignment_group\\\" : \\\"<work_notes>\\\", \\\"work_notes\\\" : \\\"<work_notes>\\\", \\\"cmdb_ci\\\" : \\\"<cmdb_ci>\\\", \\\"urgency\\\" : \\\"<urgency>\\\", \\\"impact\\\" : \\\"<impact>\\\", \\\"priority\\\" : \\\"<priority>\\\" }\" }, \"tableName\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"Name of the table from which to retrieve the records.\", \"extensions\" : { \"in\" : \"path\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"incident\\\"\" }, \"BasicAuth\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"The asset_id of the connection that matches type:OPENAPI and auth_mechanism:basic\", \"extensions\" : { \"in\" : \"header\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"service_now\\\"\" } }",
-  "children" : ["060b85ad-bfda-436c-a187-2c5cc20d9b1d"],
+  "arguments" : "{ \"url\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"{url}/api/now - will be overwritten with asset_id connection 'url' field\", \"default\" : \"https://demo.servicenow.com\", \"extensions\" : { \"in\" : \"server\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"<asset_url>\\\"\" }, \"requestBody\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"object\", \"extensions\" : { \"in\" : \"body\", \"mediaType\" : \"application/json\" } }, \"required\" : false, \"sensitive\" : false, \"runAsProject\" : true, \"expression\" : \"\\\"$payload.result\\\"\" }, \"tableName\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"Name of the table from which to retrieve the records.\", \"extensions\" : { \"in\" : \"path\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"incident\\\"\" }, \"BasicAuth\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"string\", \"description\" : \"To connect to Service Now, the asset_id of the connection that matches type:OPENAPI and auth_mechanism:basic\", \"extensions\" : { \"in\" : \"header\" } }, \"required\" : true, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"$start.arguments.asset_id\\\"\" } }",
+  "children" : ["282445d9-f592-463d-8708-e7cc272b78d4"],
   "action" : "servicenow:create_record",
   "asynchronous" : false
 },
 {
-  "_id" : "060b85ad-bfda-436c-a187-2c5cc20d9b1d",
+  "_id" : "282445d9-f592-463d-8708-e7cc272b78d4",
   "name" : "End",
   "shortname" : "end",
   "type" : "end_node",
-  "playbook" : "23fc49be-ca46-489e-bb9b-f64382df9b78",
+  "playbook" : "ce209970-c125-4b75-8790-94579e305b0f",
   "errorStatus" : "fail",
-  "result" : "{ \"schema\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"object\", \"additionalProperties\" : { } } }, \"sensitive\" : false, \"expression\" : \"{ \\\"$cond\\\" : { \\\"if\\\" : { \\\"$eq\\\" : [\\\"$start.arguments.run_type\\\", \\\"row\\\"] }, \\\"then\\\" : [{ \\\"Incident Number\\\" : \\\"$create_record_sonark.result.result.number\\\" }], \\\"else\\\" : { \\\"if\\\" : { \\\"$eq\\\" : [\\\"$start.arguments.run_type\\\", \\\"direct\\\"] }, \\\"then\\\" : [{ \\\"Incident Number\\\" : \\\"$create_record_direct.result.result.number\\\" }], \\\"else\\\" : \\\"\\\" } } }\" }"
-},
-{
-  "_id" : "6b9b22e9-517c-405b-81f5-d5ec8ec59fc8",
-  "name" : "Create Record Direct",
-  "shortname" : "create_record",
-  "type" : "action_node",
-  "playbook" : "23fc49be-ca46-489e-bb9b-f64382df9b78",
-  "errorStatus" : "fail",
-  "arguments" : "{ \"url\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"{url}/api/now - will be overwritten with asset_id connection 'url' field\", \"default\" : \"https://demo.servicenow.com\", \"extensions\" : { \"in\" : \"server\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"<asset_url>\\\"\" }, \"requestBody\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"object\", \"default\" : { \"short_description\" : \"<short_description>\", \"description\" : \"$events_loop.item.arn\", \"assignment_group\" : \"<assignment_group>\", \"work_notes\" : \"<work_notes>\", \"cmdb_ci\" : \"<cmdb_ci>\", \"urgency\" : \"<urgency>\", \"impact\" : \"<impact>\", \"priority\" : \"<priority>\" }, \"extensions\" : { \"in\" : \"body\", \"mediaType\" : \"application/json\" }, \"properties\" : { \"short_description\" : { \"type\" : \"string\" } } }, \"required\" : false, \"sensitive\" : false }, \"tableName\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"Name of the table from which to retrieve the records.\", \"extensions\" : { \"in\" : \"path\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"incident\\\"\" }, \"BasicAuth\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"The asset_id of the connection that matches type:OPENAPI and auth_mechanism:basic\", \"extensions\" : { \"in\" : \"header\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"service_now\\\"\" } }",
-  "children" : ["060b85ad-bfda-436c-a187-2c5cc20d9b1d"],
-  "action" : "servicenow:create_record",
-  "asynchronous" : false
+  "result" : "{ \"schema\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"object\", \"additionalProperties\" : { } } }, \"sensitive\" : false, \"expression\" : \"[{\\r\\n  \\\"Incident Number\\\" : \\\"$create_incident.result.result.number\\\"\\r\\n}]\" }"
 }]


### PR DESCRIPTION
Change the playbook to use `$$data` as the document to create the incident instead of querying the collections looking for the _id. This method is more reliable and easier to maintain.

Another change was to add the `asset_id` to the playbook parameters. There's a default value `service_now`, it doesn't need to be edited if the instructions are followed, but if the `asset_id` is different than the default then it can be edited in the index-pattern button instead of changing the playbook.

The option to run in bulk is not possible in this playbook but that can be added in a future version on in another playbook that wraps this one. 

##  Clean up instructions playbook "Create Service Now Incident"
Follow these steps on customers that have the version 1 of the playbook installed.
### sonargd.session
1. Navigate to Home->System Management->SonarK Management->Index Patterns.
1. Search for `session`, and select the `sonargd-session` collection.
1. Navigate to Scripted Fields, and remove scripted field `id_string`.
1. Navigate to Actions->Row, and click the trash can icon to remove `Create SNOW Incident`.
### sonargd.instance
1. Navigate to Home->System Management->SonarK Management->Index Patterns.
1. Search for `instance`, and select the `sonargd-instance` collection.
1. Navigate to Actions->Row, and click the trash can icon to remove `Create SNOW Incident`.