### PR TITLE
Add cmdb table data to create incident playbook

### DIFF
--- a/integrations/playbooks/ServiceNow_Incident/create_snow_incident_record.json
+++ b/integrations/playbooks/ServiceNow_Incident/create_snow_incident_record.json
@@ -1,6 +1,6 @@
 [
 {
-  "_id" : "ce209970-c125-4b75-8790-94579e305b0f",
+  "_id" : "bb58055f-4886-48ba-a17c-7b81c06da150",
   "name" : "Create SNOW Incident Record",
   "description" : "",
   "type" : "playbook",
@@ -10,11 +10,11 @@
     "collection" : "playbook_definitions",
     "page" : "playbooks.xhtml"
   },
-  "version" : 2,
+  "version" : 3,
   "enabled" : true,
   "onlyWarehouse" : false,
   "created" : {
-    "$date" : "2022-11-13T03:23:58.252Z"
+    "$date" : "2022-11-15T02:13:00.941Z"
   },
   "playbook" : {
     "_id" : "18d7a1bb-80d0-490e-bcdc-99c630329a64",
@@ -27,52 +27,70 @@
       "collection" : "playbook_definitions",
       "page" : "playbooks.xhtml"
     },
-    "version" : 2,
+    "version" : 3,
     "enabled" : true,
-    "onlyWarehouse" : false
+    "onlyWarehouse" : false,
+    "created" : {
+      "$date" : "2022-11-15T02:12:56.005Z"
+    },
+    "playbook" : {
+      "_id" : "18d7a1bb-80d0-490e-bcdc-99c630329a64",
+      "name" : "Create SNOW Incident Record",
+      "description" : "",
+      "type" : "playbook",
+      "category" : "ServiceNow Incident",
+      "source" : {
+        "database" : "lmrm__ae",
+        "collection" : "playbook_definitions",
+        "page" : "playbooks.xhtml"
+      },
+      "version" : 3,
+      "enabled" : true,
+      "onlyWarehouse" : false
+    }
   }
 },
 {
-  "_id" : "7be42e69-5541-4b7b-979c-34c0b2ecac1a",
+  "_id" : "807fc272-7aaf-4006-b214-cc18771c4c1e",
   "name" : "Create Incident Record",
   "shortname" : "start",
   "type" : "root_node",
-  "playbook" : "ce209970-c125-4b75-8790-94579e305b0f",
+  "playbook" : "bb58055f-4886-48ba-a17c-7b81c06da150",
   "errorStatus" : "fail",
   "arguments" : "{ \"event\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"object\", \"title\" : \"Event\", \"default\" : { } }, \"required\" : true, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false }, \"comment\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"string\", \"title\" : \"Comment\" }, \"required\" : false, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false }, \"asset_id\" : { \"inputType\" : \"prompt\", \"schema\" : { \"type\" : \"string\", \"title\" : \"Service Now asset_id\", \"description\" : \"To connect to Service Now, the asset_id of the connection that matches type:OPENAPI and auth_mechanism:basic\", \"default\" : \"service_now\" }, \"required\" : true, \"sensitive\" : false, \"contextVariable\" : false, \"alwaysPrompt\" : false } }",
-  "children" : ["da2fde7a-96d9-44d5-910d-f84a6c4a47b3"]
+  "children" : ["e12d3595-2e4b-48d6-b498-859b360f2056"]
 },
 {
-  "_id" : "da2fde7a-96d9-44d5-910d-f84a6c4a47b3",
+  "_id" : "e12d3595-2e4b-48d6-b498-859b360f2056",
   "name" : "Massage payload for servicenow",
   "shortname" : "payload",
   "type" : "stamp_node",
-  "playbook" : "ce209970-c125-4b75-8790-94579e305b0f",
+  "playbook" : "bb58055f-4886-48ba-a17c-7b81c06da150",
   "errorStatus" : "fail",
-  "arguments" : "{ \"short_description\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"Server Hostname: $start.arguments.event.Server Host Name\\\\nDatabase Name: $start.arguments.event.Database Name\\\\nDB User Name: $start.arguments.event.DB User Name\\\"\" }, \"description\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"Server Hostname: $start.arguments.event.Server Host Name\\\\nDatabase Name: $start.arguments.event.Database Name\\\\nDB User Name: $start.arguments.event.DB User Name\\\\nComment: $start.arguments.comment\\\"\" }, \"event\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"object\" }, \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"$start.arguments.event\\\"\" } }",
-  "result" : "{ \"schema\" : { \"type\" : \"object\" }, \"sensitive\" : false, \"expression\" : \"{ \\\"short_description\\\" : \\\"$payload.arguments.short_description\\\", \\\"description\\\" : \\\"$payload.arguments.description\\\", \\\"assignment_group\\\" : \\\"<work_notes>\\\", \\\"work_notes\\\" : \\\"<work_notes>\\\", \\\"cmdb_ci\\\" : \\\"<cmdb_ci>\\\", \\\"urgency\\\" : \\\"<urgency>\\\", \\\"impact\\\" : \\\"<impact>\\\", \\\"priority\\\" : \\\"<priority>\\\" }\" }",
-  "children" : ["f7a66e87-31cf-42b8-a0a8-ca93b9bbe9cf"],
+  "arguments" : "{ \"short_description\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"Server Hostname: $start.arguments.event.Server Host Name\\\\nDatabase Name: $start.arguments.event.Database Name\\\\nDB User Name: $start.arguments.event.DB User Name\\\"\" }, \"description\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"Server Hostname: $start.arguments.event.Server Host Name\\\\nDatabase Name: $start.arguments.event.Database Name\\\\nDB User Name: $start.arguments.event.DB User Name\\\\nComment: $start.arguments.comment\\\"\" }, \"event\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"object\" }, \"required\" : false, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"$start.arguments.event\\\"\" }, \"cmdb_table_data\" : { \"inputType\" : \"bind\", \"required\" : false, \"sensitive\" : false, \"runAsProject\" : true, \"expression\" : \"\\\"$cmdb_table_data\\\"\", \"enrichment\" : \"[{ \\\"$project\\\" : { \\\"event_fqdn\\\" : { \\\"$ifNull\\\" : [\\\"$start.arguments.event.Agent Name\\\", \\\"$start.arguments.event.Server Host Name\\\"] }, \\\"*\\\" : 1 } }, { \\\"$join\\\" : { \\\"$joined\\\" : { \\\"servicenow_cmdb_table_data\\\" : { \\\"$ns\\\" : \\\"servicenow_cmdb_table_data\\\", \\\"$db\\\" : \\\"sonargd\\\" } }, \\\"$outer\\\" : [\\\"servicenow_cmdb_table_data\\\"], \\\"$match\\\" : [{ \\\"event_fqdn\\\" : { \\\"$oneToOne\\\" : \\\"$servicenow_cmdb_table_data.$fqdn\\\" } }], \\\"$project\\\" : { \\\"*\\\" : 1, \\\"cmdb_table_data\\\" : \\\"$servicenow_cmdb_table_data.$*\\\" } } }]\" } }",
+  "result" : "{ \"schema\" : { \"type\" : \"object\" }, \"sensitive\" : false, \"expression\" : \"{ \\\"short_description\\\" : \\\"$payload.arguments.short_description\\\", \\\"description\\\" : \\\"$payload.arguments.description\\\", \\\"assignment_group\\\" : \\\"<work_notes>\\\", \\\"work_notes\\\" : \\\"<work_notes>\\\", \\\"cmdb_ci\\\" : { \\\"$ifNull\\\" : [\\\"$payload.arguments.cmdb_table_data.fqdn\\\", \\\"N/A\\\"] }, \\\"urgency\\\" : \\\"<urgency>\\\", \\\"impact\\\" : \\\"<impact>\\\", \\\"priority\\\" : \\\"<priority>\\\" }\" }",
+  "children" : ["d6b37c39-1a79-4985-a839-917e732c407a"],
   "stamp" : "success",
   "message" : ""
 },
 {
-  "_id" : "f7a66e87-31cf-42b8-a0a8-ca93b9bbe9cf",
+  "_id" : "d6b37c39-1a79-4985-a839-917e732c407a",
   "name" : "Create Incident",
   "shortname" : "create_incident",
   "type" : "action_node",
-  "playbook" : "ce209970-c125-4b75-8790-94579e305b0f",
+  "playbook" : "bb58055f-4886-48ba-a17c-7b81c06da150",
   "errorStatus" : "fail",
   "arguments" : "{ \"url\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"{url}/api/now - will be overwritten with asset_id connection 'url' field\", \"default\" : \"https://demo.servicenow.com\", \"extensions\" : { \"in\" : \"server\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"<asset_url>\\\"\" }, \"requestBody\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"object\", \"extensions\" : { \"in\" : \"body\", \"mediaType\" : \"application/json\" } }, \"required\" : false, \"sensitive\" : false, \"runAsProject\" : true, \"expression\" : \"\\\"$payload.result\\\"\" }, \"tableName\" : { \"inputType\" : \"literal\", \"schema\" : { \"type\" : \"string\", \"description\" : \"Name of the table from which to retrieve the records.\", \"extensions\" : { \"in\" : \"path\" } }, \"required\" : true, \"sensitive\" : false, \"value\" : \"\\\"incident\\\"\" }, \"BasicAuth\" : { \"inputType\" : \"bind\", \"schema\" : { \"type\" : \"string\", \"description\" : \"To connect to Service Now, the asset_id of the connection that matches type:OPENAPI and auth_mechanism:basic\", \"extensions\" : { \"in\" : \"header\" } }, \"required\" : true, \"sensitive\" : false, \"runAsProject\" : false, \"expression\" : \"\\\"$start.arguments.asset_id\\\"\" } }",
-  "children" : ["282445d9-f592-463d-8708-e7cc272b78d4"],
+  "children" : ["c1791a2a-0ffc-4d98-b4ee-0c6bc4ab4b6d"],
   "action" : "servicenow:create_record",
   "asynchronous" : false
 },
 {
-  "_id" : "282445d9-f592-463d-8708-e7cc272b78d4",
+  "_id" : "c1791a2a-0ffc-4d98-b4ee-0c6bc4ab4b6d",
   "name" : "End",
   "shortname" : "end",
   "type" : "end_node",
-  "playbook" : "ce209970-c125-4b75-8790-94579e305b0f",
+  "playbook" : "bb58055f-4886-48ba-a17c-7b81c06da150",
   "errorStatus" : "fail",
   "result" : "{ \"schema\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"object\", \"additionalProperties\" : { } } }, \"sensitive\" : false, \"expression\" : \"[{\\r\\n  \\\"Incident Number\\\" : \\\"$create_incident.result.result.number\\\"\\r\\n}]\" }"
 }]


### PR DESCRIPTION
Added a new field called `cmdb_table_data` to the `payload` node. The data is the result of a `join` from the event, either `Agent Name` or `Server Host Name`, matching with `fqdn` from `sonargd.service_now_cmdb_table_data`.